### PR TITLE
Added venv description to README and spaCy to requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ For more information on the Rasa Stack, please visit the docs here:
 
 ## Setup
 
+In order to avoid modifying your system state, we recommend the use of a virtual environment. Python 3's distribution comes with `venv` preinstalled:
+
+```
+python -m venv venv
+source venv/bin/activate
+```
+
+You can of course also use `virtualenv` etc. The `venv` folder is already in the `.gitignore` of this project.
+
 To install the necessary requirements, run:
 
 ```
@@ -24,4 +33,4 @@ To run the bot on the command line run ``make cmdline``
 
 ## What now?
 
-To continue developing your bot, you can start by adding some NLU data for intents/entities relevant to your use case. These then need to be added to your domain file. From there you can add more utterances for the bot, or custom actions you've written in `actions.py` and then write stories using these. 
+To continue developing your bot, you can start by adding some NLU data for intents/entities relevant to your use case. These then need to be added to your domain file. From there you can add more utterances for the bot, or custom actions you've written in `actions.py` and then write stories using these.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+spacy
 -e git+https://github.com/RasaHQ/rasa_core.git@d63f55c44cd919d2031311201caa1c26c94cb365#egg=rasa_core
 rasa_nlu==0.12.0
 gspread==2.0.0


### PR DESCRIPTION
Hi Rasa team, 

I think it makes sense to explain the need for `venv` or another virtual environment given the amount of packages that are installed here. While most Python devs do this by default, you might encounter a lot of non-Python devs in the future (or people who are used to using Docker all the time) 

Normally I would have done `python -m venv .venv` but `venv` was already in your `.gitignore`, so I decided to roll with it. 

Furthermore, I added `spacy` to the requirements.txt. Not sure why it's missing? Is it in the dependencies of Rasa NLU and/or Core already? 

Open to feedback on the suggestions.